### PR TITLE
2020.07.27 commit from yoon

### DIFF
--- a/Server/server_0502.py
+++ b/Server/server_0502.py
@@ -99,7 +99,7 @@ def faceAnalyse(FILE_NAME):
         recog_index = 0
         if gender == 'female':
             recog_index += 6
-        recog_index += int((final_age//10)) - 1
+        recog_index += int((final_age//10)) - 1 if int((final_age//10)) <= 6 else 6
         recog_result[recog_index] += 1
 
     cv2.imwrite(FILE_NAME, img)
@@ -515,12 +515,12 @@ class ServerThread(Thread):
             global disConn
             conn, (ip, port) = tcpServer.accept()
 
-            if ip == '192.168.142.189':
+            if ip == '192.168.140.255':
                 camConn = conn
                 camthread = CameraThread(ip, port, window)
                 camthread.start()
                 threads.append(camthread)
-            if ip == '192.168.103.67':
+            if ip == '192.168.103.72':
                 disConn = conn
                 disthread = DisplayThread(ip, port, window)
                 disthread.start()


### PR DESCRIPTION
1. 서버의 faceAnalyse 메소드 수정
연령대 인식 결과가 60대를 초과할 경우 옳지 않은 인덱스 값을 지정하는 문제 해결
삼항연산자 활용해서 연령대가 70 이상으로 나오면 60대로 간주